### PR TITLE
Fixed a typo in a CSS class

### DIFF
--- a/examples/sexy-vanilla/index.html
+++ b/examples/sexy-vanilla/index.html
@@ -75,20 +75,20 @@
 		.char5 { position:relative; top:-30px; left:-2px; }
 		.char6 { font-size:120px; }
 		.char7 { position:relative; top:-15px; left:0px; }
-		.char8 { position:relativeS; top:-20px; left:4px; }
+		.char8 { position:relative; top:-20px; left:4px; }
 		.char9 { position:relative; top:-25px; left:6px; }
 		.char10 { position:relative; top:-30px; left:8px; }
 		.char11 { position:relative; top:-35px; left:12px; }
 		.char12 { position:relative; top:-40px; left:14px; }
 		.char13 { position:relative; top:-48px; left:20px; }
-		.char14 { position:relative; top:-56px; left:24px; }​
+		.char14 { position:relative; top:-56px; left:24px; }
 	</style>
 </head>
 <body>
 	<div id="content">
 		<h1 class="sexy">Sexy Vanilla!</h1>
 		<h2>Lettering.js</h2>
-	</div>​​​​​​​​​​
+	</div>
 	<script type="text/javascript" src="http://rlemon.com/public_files/Sizzle.js"></script>
 	<script type="text/javascript">
 	


### PR DESCRIPTION
There was a S in the `.char8` classes' position rule and some weird unrecognized characters in two locations which I removed.
